### PR TITLE
Tweak description punctuation

### DIFF
--- a/src/epub/content.opf
+++ b/src/epub/content.opf
@@ -42,7 +42,7 @@
 		<meta property="se:subject">Science Fiction</meta>
 		<dc:description id="description">A motley collection of servicemembers escape a plot as two mysterious factions wage an epic war across time itself.</dc:description>
 		<meta id="long-description" property="se:long-description" refines="#description">
-			&lt;p&gt;At the time of the release of this ebook edition of &lt;i&gt;The Big Time&lt;/i&gt;, it remains the only Hugo-award-winning work in the public domain. That makes it a very special treasure indeed!&lt;/p&gt;
+			&lt;p&gt;At the time of the release of this ebook edition of &lt;i&gt;The Big Time&lt;/i&gt;, it remains the only Hugo Award–winning work in the public domain. That makes it a very special treasure indeed!&lt;/p&gt;
 			&lt;p&gt;&lt;i&gt;The Big Time&lt;/i&gt; tells the tale of a group of servicemembers who work in facilities isolated from regular space-time. They’re involved in a war conducted by two shadowy groups that spans time itself, with all of humanity as pawns on an ever-changing historical battlefield. It explores a fascinating range of themes including time travel, the purpose of war, isolation, and love in the face of it all.&lt;/p&gt;
 		</meta>
 		<dc:language>en-US</dc:language>


### PR DESCRIPTION
Changes “Hugo-award-winning” (two hyphens) to “Hugo Award–winning” (space and en dash).

According to [Wikipedia](https://en.wikipedia.org/wiki/Dash#Attributive_compounds), en dash is the right choice for an attributive compound (⸺-winning) containing another compound (Hugo Award).

Also capitalized “Award.”